### PR TITLE
Remove @EnableDiscoveryClient annotation

### DIFF
--- a/spring-boot-admin/src/main/java/org/example/teahouse/sba/SbaApplication.java
+++ b/spring-boot-admin/src/main/java/org/example/teahouse/sba/SbaApplication.java
@@ -6,12 +6,10 @@ import org.example.teahouse.core.actuator.config.CommonActuatorConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 
 @EnableAdminServer
-@EnableDiscoveryClient
 @SpringBootApplication
 @PropertySource("classpath:build.properties")
 @Import({CommonActuatorConfig.class})

--- a/tea-service/src/main/java/org/example/teahouse/tea/TeaServiceApplication.java
+++ b/tea-service/src/main/java/org/example/teahouse/tea/TeaServiceApplication.java
@@ -3,13 +3,11 @@ package org.example.teahouse.tea;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.PropertySource;
 
 @EnableFeignClients
-@EnableDiscoveryClient
 @SpringBootApplication
 @PropertySource("classpath:build.properties")
 @ComponentScan(basePackages = { "org.example.teahouse" })

--- a/tealeaf-service/src/main/java/org/example/teahouse/tealeaf/TealeafServiceApplication.java
+++ b/tealeaf-service/src/main/java/org/example/teahouse/tealeaf/TealeafServiceApplication.java
@@ -3,11 +3,9 @@ package org.example.teahouse.tealeaf;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.PropertySource;
 
-@EnableDiscoveryClient
 @SpringBootApplication
 @PropertySource("classpath:build.properties")
 @ComponentScan(basePackages = { "org.example.teahouse" })

--- a/water-service/src/main/java/org/example/teahouse/water/WaterServiceApplication.java
+++ b/water-service/src/main/java/org/example/teahouse/water/WaterServiceApplication.java
@@ -3,11 +3,9 @@ package org.example.teahouse.water;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.PropertySource;
 
-@EnableDiscoveryClient
 @SpringBootApplication
 @PropertySource("classpath:build.properties")
 @ComponentScan(basePackages = { "org.example.teahouse" })


### PR DESCRIPTION
According to the Official Spring Cloud docs, the `@EnableDiscoveryClient` annotation is not required anymore:
>`@EnableDiscoveryClient` is no longer required. You can put a `DiscoveryClient` implementation on the classpath to cause the Spring Boot application to register with the service discovery server."

See: https://docs.spring.io/spring-cloud-commons/reference/4.1/spring-cloud-commons/common-abstractions.html#discovery-client