### PR TITLE
Remove version property from compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     mysql:
         container_name: mysql


### PR DESCRIPTION
Hi,
I stumbled upon one more trivial warning.  `version` element in `docker-compose.yml` is no longer needed:
```
WARN[0000] <omitted>/docker-compose.yml: `version` is obsolete
```

See https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete